### PR TITLE
SHA1 support

### DIFF
--- a/svndump/common.py
+++ b/svndump/common.py
@@ -78,6 +78,23 @@ def is_valid_md5_string(md5):
     return True
 
 
+def is_valid_sha1_string(sha1):
+    """
+    Checks a sha1 string.
+
+    @type sha1: object
+    @param sha1: SHA1 string.
+    @rtype: bool
+    @return: True if the string looks like an sha1 sum.
+    """
+
+    if len(sha1) != 40:
+        return False
+    if sha1.lower().strip("0123456789abcdef") != "":
+        return False
+    return True
+
+
 class SvnDumpException(Exception):
     """A simple exception class."""
 

--- a/svndump/file.py
+++ b/svndump/file.py
@@ -187,7 +187,7 @@ class SvnDumpFile:
             # key
             words = line.split()
             if len(words) != 2 or (words[0] != "K" and words[0] != "D"):
-                raise SvnDumpException("illegal proprty key ???")
+                raise SvnDumpException("illegal property key ???")
             key = self.__read_bin(int(words[1]))
             self.__skip_empty_line()
             # value
@@ -196,7 +196,7 @@ class SvnDumpFile:
                 eof, line = self.__read_line(True)
                 words = line.split()
                 if len(words) != 2 or words[0] != "V":
-                    raise SvnDumpException("illegal proprty value ???")
+                    raise SvnDumpException("illegal property value ???")
                 value = self.__read_bin(int(words[1]))
                 self.__skip_empty_line()
             # set property

--- a/svndump/file.py
+++ b/svndump/file.py
@@ -488,10 +488,15 @@ class SvnDumpFile:
                 md5 = tags["Text-content-md5:"]
             else:
                 md5 = ""
+            if tags.has_key("Text-content-sha1:"):
+                sha1 = tags["Text-content-sha1:"]
+            else:
+                sha1 = ""
             if tags.has_key("Text-content-length:"):
                 node.set_text_fileobj(self.__file, offset,
                                       int(tags["Text-content-length:"]),
-                                      md5)
+                                      md5,
+                                      sha1)
             upath = (action[0].upper(), path)
             self.__nodes[upath] = node
             # next one...
@@ -803,13 +808,15 @@ class SvnDumpFile:
                 totlen = proplen + textlen
             else:
                 totlen = proplen
+            if node.has_md5():
+                self.__file.write("Text-content-md5: %s\n" % node.get_text_md5())
+            if node.has_sha1():
+                self.__file.write("Text-content-sha1: %s\n" % node.get_text_sha1())
             # write length's of properties text and total
             if proplen > 0:
                 self.__file.write("Prop-content-length: %d\n" % proplen)
             if node.has_text():
                 self.__file.write("Text-content-length: %d\n" % textlen)
-            if node.has_md5():
-                self.__file.write("Text-content-md5: %s\n" % node.get_text_md5())
             if proplen > 0 or node.has_text():
                 self.__file.write("Content-length: %d\n" % totlen)
                 self.__file.write("\n")


### PR DESCRIPTION
Add support for sha1 checksums.

Recently I needed to fix some eol issues in some svn dumps.
The issues were fixed but I noticed that some lines from the original dump files were missing: `Text-content-sha1`.

I implemented sha1 support simply by copying the md5 code and adapt it to sha1.

The only tests I run were my eol fixes: `svndumptool.py eolfix-prop svn:ignore defect_svn_dump.txt fixed_svn_dump.txt`

I also changed the place were the lines with the checksums are written in `SvnDumpFile#add_node` - 
that way the positions of these lines in the dump file match the original places which reduces the number of diffs between the dump files (before and after the fix).
(The svn dump files I used were created by `svnadmin, version 1.8.10 (r1615264)`.)